### PR TITLE
Connection status header and calling server methods; fixes #35

### DIFF
--- a/DEHPEcosimPro.Tests/DstController/DstControllerTestFixture.cs
+++ b/DEHPEcosimPro.Tests/DstController/DstControllerTestFixture.cs
@@ -78,6 +78,8 @@ namespace DEHPEcosimPro.Tests.DstController
             Assert.IsEmpty(this.controller.Variables);
             Assert.IsNull(this.controller.References);
             Assert.IsEmpty(this.controller.Methods);
+            Assert.Null(this.controller.ServerAddress);
+            Assert.Zero(this.controller.RefreshInterval);
         }
 
         [Test]

--- a/DEHPEcosimPro.Tests/DstController/DstControllerTestFixture.cs
+++ b/DEHPEcosimPro.Tests/DstController/DstControllerTestFixture.cs
@@ -25,6 +25,8 @@
 namespace DEHPEcosimPro.Tests.DstController
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
 
     using DEHPCommon.HubController.Interfaces;
@@ -47,15 +49,25 @@ namespace DEHPEcosimPro.Tests.DstController
         private Mock<IHubController> hubController;
         private Mock<IOpcSessionHandler> opcSessionHandler;
 
+        private List<ReferenceDescription> referenceDescriptionCollection = new List<ReferenceDescription>
+        {
+            new ReferenceDescription { NodeId = ExpandedNodeId.Parse("server_methods"), BrowseName = new QualifiedName("server_methods"), NodeClass = NodeClass.Object},
+            new ReferenceDescription { NodeId = ExpandedNodeId.Parse("method_run"), BrowseName = new QualifiedName("method_run"), NodeClass = NodeClass.Method},
+            new ReferenceDescription { NodeId = ExpandedNodeId.Parse("method_reset"),BrowseName = new QualifiedName("method_reset"), NodeClass = NodeClass.Method},
+        };
+
         [SetUp]
         public void Setup()
         {
             this.hubController = new Mock<IHubController>();
             this.opcSessionHandler = new Mock<IOpcSessionHandler>();
-    
+
             this.opcClient = new Mock<IOpcClientService>();
             this.opcClient.Setup(x => x.Connect(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<IUserIdentity>())).Returns(Task.CompletedTask);
             this.opcClient.Setup(x => x.CloseSession());
+            this.opcClient.Setup(x => x.ReadNode(Variables.Server_ServerStatus_StartTime)).Returns(new DataValue(new DateTime(2021, 1, 1)));
+            this.opcClient.Setup(x => x.ReadNode(Variables.Server_ServerStatus_CurrentTime)).Returns(new DataValue(new DateTime(2021, 1, 3)));
+
             this.controller = new DstController(this.opcClient.Object, this.hubController.Object, this.opcSessionHandler.Object);
         }
 
@@ -88,13 +100,52 @@ namespace DEHPEcosimPro.Tests.DstController
             Assert.DoesNotThrow(() =>
             {
                 this.controller.AddSubscription(new ReferenceDescription() { NodeId = new ExpandedNodeId(Guid.NewGuid()) });
-            this.controller.AddSubscription(new ReferenceDescription() { NodeId = new ExpandedNodeId(Guid.NewGuid())});
+                this.controller.AddSubscription(new ReferenceDescription() { NodeId = new ExpandedNodeId(Guid.NewGuid()) });
             });
 
             this.opcClient.Verify(x => x.AddSubscription(It.IsAny<NodeId>()), Times.Exactly(2));
 
             this.controller.ClearSubscriptions();
             this.opcSessionHandler.Verify(x => x.ClearSubscriptions(), Times.Once);
+        }
+
+        [Test]
+        public void VerifyCallServerMethod()
+        {
+            this.opcClient.Setup(x => x.References).Returns(new ReferenceDescriptionCollection(this.referenceDescriptionCollection));
+
+            foreach (var referenceDescription in this.referenceDescriptionCollection.Where(r => r.NodeClass == NodeClass.Method))
+            {
+                this.controller.Methods.Add(referenceDescription);
+            }
+
+            Assert.IsNull(this.controller.CallServerMethod("unknown_method"));
+
+            Assert.DoesNotThrow(() => this.controller.CallServerMethod("method_run"));
+            this.opcClient.Verify(x => x.CallMethod(new NodeId("server_methods"), new NodeId("method_run"), string.Empty), Times.Once);
+
+            Assert.DoesNotThrow(() => this.controller.CallServerMethod("method_reset"));
+            this.opcClient.Verify(x => x.CallMethod(new NodeId("server_methods"), new NodeId("method_reset"), string.Empty), Times.Once);
+        }
+
+        [Test]
+        public void VerifyGetServerStartTime()
+        {
+            Assert.IsNull(this.controller.GetServerStartTime());
+
+            this.controller.IsSessionOpen = true;
+            Assert.AreEqual(new DateTime(2021, 1, 1), this.controller.GetServerStartTime());
+            this.opcClient.Verify(x => x.ReadNode(Variables.Server_ServerStatus_StartTime), Times.Once);
+        }
+
+        [Test]
+        public void VerifyGetCurrentServerTime()
+        {
+            Assert.IsNull(this.controller.GetCurrentServerTime());
+
+            this.controller.IsSessionOpen = true;
+            Assert.AreEqual(new DateTime(2021, 1, 3), this.controller.GetCurrentServerTime());
+            this.opcClient.Verify(x => x.ReadNode(Variables.Server_ServerStatus_CurrentTime), Times.Once);
         }
     }
 }

--- a/DEHPEcosimPro.Tests/Services/OpcConnector/OpcClientTestFixture.cs
+++ b/DEHPEcosimPro.Tests/Services/OpcConnector/OpcClientTestFixture.cs
@@ -125,9 +125,9 @@ namespace DEHPEcosimPro.Tests.Services.OpcConnector
             var identifier = (NodeId)this.referenceDescriptionCollection.First().NodeId;
             Assert.DoesNotThrow(() => this.client.AddSubscription(identifier));
             this.sessionHandler.Setup(x => x.AddSubscription(It.IsAny<Subscription>())).Throws<InvalidOperationException>();
-            this.statusBarViewModel.Verify(x => x.Append(It.IsAny<string>(), It.IsAny<StatusBarMessageSeverity>()), Times.Exactly(18));
+            this.statusBarViewModel.Verify(x => x.Append(It.IsAny<string>(), It.IsAny<StatusBarMessageSeverity>()), Times.Exactly(17));
             Assert.DoesNotThrow(() => this.client.AddSubscription(identifier));
-            this.statusBarViewModel.Verify(x => x.Append(It.IsAny<string>(), It.IsAny<StatusBarMessageSeverity>()), Times.Exactly(20));
+            this.statusBarViewModel.Verify(x => x.Append(It.IsAny<string>(), It.IsAny<StatusBarMessageSeverity>()), Times.Exactly(19));
             var errorMessage = $"Error creating subscription for attribute id = 13";
             this.statusBarViewModel.Verify(x => x.Append(errorMessage, StatusBarMessageSeverity.Error), Times.Exactly(1));
         }

--- a/DEHPEcosimPro.Tests/ViewModel/DstBrowserHeaderViewModelTestFixture.cs
+++ b/DEHPEcosimPro.Tests/ViewModel/DstBrowserHeaderViewModelTestFixture.cs
@@ -1,0 +1,141 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="DstVariablesControlViewModelTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2020 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
+// 
+//    This file is part of DEHPEcosimPro
+// 
+//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHPEcosimPro.Tests.ViewModel
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reactive.Concurrency;
+
+    using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
+
+    using DEHPEcosimPro.DstController;
+    using DEHPEcosimPro.ViewModel;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using Opc.Ua;
+    using Opc.Ua.Client;
+
+    using ReactiveUI;
+
+    [TestFixture]
+    public class DstBrowserHeaderViewModelTestFixture
+    {
+        private DstBrowserHeaderViewModel viewModel;
+        private Mock<IDstController> dstController;
+        private Mock<IStatusBarControlViewModel> statusBarViewModel;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.dstController = new Mock<IDstController>();
+            this.statusBarViewModel = new Mock<IStatusBarControlViewModel>();
+
+            this.dstController.Setup(x => x.IsSessionOpen).Returns(false);
+
+            this.dstController.Setup(x => x.AddSubscription(It.IsAny<ReferenceDescription>()));
+
+            this.dstController.Setup(x => x.Variables).Returns(
+                new List<(ReferenceDescription Reference, DataValue Value)>()
+                {
+                    (new ReferenceDescription()
+                    {
+                        NodeId = new ExpandedNodeId(Guid.NewGuid()), DisplayName = new LocalizedText("", "DummyVariable0")
+                    }, new DataValue()),
+                    (new ReferenceDescription()
+                    {
+                        NodeId = new ExpandedNodeId(Guid.NewGuid()), DisplayName = new LocalizedText("", "DummyVariable1")
+                    }, new DataValue()),
+                    (new ReferenceDescription()
+                    {
+                        NodeId = new ExpandedNodeId(Guid.NewGuid()), DisplayName = new LocalizedText("", "DummyVariable2")
+                    }, new DataValue()),
+                });
+
+            this.dstController.Setup(x => x.ServerAddress).Returns("dummyAddress");
+            this.dstController.Setup(x => x.RefreshInterval).Returns(500);
+            this.dstController.Setup(x => x.GetServerStartTime()).Returns(new DateTime(2021, 1, 1));
+            this.dstController.Setup(x => x.GetCurrentServerTime()).Returns(new DateTime(2021, 1, 3));
+
+            this.viewModel = new DstBrowserHeaderViewModel(this.dstController.Object, this.statusBarViewModel.Object);
+        }
+
+        [Test]
+        public void VerifyProperties()
+        {
+            Assert.IsEmpty(this.viewModel.ServerAddress);
+            Assert.Zero(this.viewModel.SamplingInterval);
+            Assert.Zero(this.viewModel.VariablesCount);
+            Assert.IsNull(this.viewModel.ServerStartTime);
+            Assert.IsNull(this.viewModel.CurrentServerTime);
+        }
+
+        [Test]
+        public void VerifyUpdateProperties()
+        {
+            RxApp.MainThreadScheduler = Scheduler.CurrentThread;
+
+            this.dstController.Setup(x => x.IsSessionOpen).Returns(true);
+            this.viewModel.UpdateProperties();
+
+            Assert.AreEqual("dummyAddress", this.viewModel.ServerAddress);
+            Assert.AreEqual(500, this.viewModel.SamplingInterval);
+            Assert.AreEqual(3, this.viewModel.VariablesCount);
+            Assert.AreEqual(new DateTime(2021, 1, 1), this.viewModel.ServerStartTime);
+            Assert.AreEqual(new DateTime(2021, 1, 3), this.viewModel.CurrentServerTime);
+
+            this.dstController.Verify(x => x.AddSubscription(It.IsAny<NodeId>()), Times.Exactly(1));
+
+            this.dstController.Setup(x => x.IsSessionOpen).Returns(false);
+            this.viewModel.UpdateProperties();
+
+            this.dstController.Verify(x => x.ClearSubscriptions(), Times.Exactly(2));
+        }
+
+        [Test]
+        public void VerifyCanCallRunMethodCommand()
+        {
+            Assert.IsFalse(this.viewModel.CallRunMethodCommand.CanExecute(null));
+
+            this.dstController.Setup(c => c.IsSessionOpen).Returns(true);
+            this.viewModel = new DstBrowserHeaderViewModel(this.dstController.Object, this.statusBarViewModel.Object);
+
+            Assert.IsTrue(this.viewModel.CallRunMethodCommand.CanExecute(null));
+        }
+
+        [Test]
+        public void VerifyCanCallResetMethodCommand()
+        {
+            Assert.IsFalse(this.viewModel.CallResetMethodCommand.CanExecute(null));
+
+            this.dstController.Setup(c => c.IsSessionOpen).Returns(true);
+            this.viewModel = new DstBrowserHeaderViewModel(this.dstController.Object, this.statusBarViewModel.Object);
+
+            Assert.IsTrue(this.viewModel.CallResetMethodCommand.CanExecute(null));
+        }
+    }
+}

--- a/DEHPEcosimPro/DstController/DstController.cs
+++ b/DEHPEcosimPro/DstController/DstController.cs
@@ -32,6 +32,7 @@ namespace DEHPEcosimPro.DstController
     using DEHPCommon.HubController.Interfaces;
 
     using DEHPEcosimPro.Enumerator;
+    using DEHPEcosimPro.Services.OpcConnector;
     using DEHPEcosimPro.Services.OpcConnector.Interfaces;
 
     using Opc.Ua;
@@ -64,7 +65,7 @@ namespace DEHPEcosimPro.DstController
         private bool isSessionOpen;
 
         /// <summary>
-        /// Assert whether the <see cref="Services.OpcConnector.OpcSessionHandler.Session"/> is Open
+        /// Assert whether the <see cref="OpcSessionHandler.OpcSession"/> is Open
         /// </summary>
         public bool IsSessionOpen
         {
@@ -195,6 +196,28 @@ namespace DEHPEcosimPro.DstController
         }
 
         /// <summary>
+        /// Calls the specified method and returns the output arguments.
+        /// </summary>
+        /// <param name="methodBrowseName">The BrowseName of the server method</param>
+        /// <param name="arguments">The arguments to input</param>
+        /// <returns>The <see cref="IList{T}"/> of output argument values, or null if the no method was found with the provided BrowseName</returns>
+        public IList<object> CallServerMethod(string methodBrowseName, params object[] arguments)
+        {
+            var serverMethodsNode = this.References.SingleOrDefault(r => r.BrowseName.Name == "server_methods")?.NodeId;
+            var methodNode = this.Methods.SingleOrDefault(m => m.BrowseName.Name == methodBrowseName)?.NodeId;
+
+            if (serverMethodsNode != null && methodNode != null)
+            {
+                return this.opcClientService.CallMethod(
+                    new NodeId(serverMethodsNode.Identifier, serverMethodsNode.NamespaceIndex),
+                    new NodeId(methodNode.Identifier, methodNode.NamespaceIndex),
+                    string.Empty);
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Removes all active subscriptions from the session.
         /// </summary>
         public void ClearSubscriptions()
@@ -203,7 +226,7 @@ namespace DEHPEcosimPro.DstController
         }
 
         /// <summary>
-        /// Closes the <see cref="Services.OpcConnector.OpcSessionHandler.Session"/>
+        /// Closes the <see cref="OpcSessionHandler.OpcSession"/>
         /// </summary>
         public void CloseSession()
         {

--- a/DEHPEcosimPro/DstController/DstController.cs
+++ b/DEHPEcosimPro/DstController/DstController.cs
@@ -152,10 +152,9 @@ namespace DEHPEcosimPro.DstController
         /// <returns>null if the session is closed or the ServerStatus.StartTime node was not found</returns>
         public DateTime? GetServerStartTime()
         {
-            var serverStartTimeNode = this.opcClientService.ReadNode(Opc.Ua.Variables.Server_ServerStatus_StartTime);
-            if (this.IsSessionOpen && serverStartTimeNode != null)
+            if (this.IsSessionOpen)
             {
-                return (DateTime)serverStartTimeNode.Value;
+                return (DateTime?)this.opcClientService.ReadNode(Opc.Ua.Variables.Server_ServerStatus_StartTime)?.Value;
             }
 
             return null;
@@ -167,11 +166,9 @@ namespace DEHPEcosimPro.DstController
         /// <returns>null if the session is closed or the ServerStatus.CurrentTime node was not found</returns>
         public DateTime? GetCurrentServerTime()
         {
-            var currentServerTimeNode = this.opcClientService.ReadNode(Opc.Ua.Variables.Server_ServerStatus_CurrentTime);
-            if (this.IsSessionOpen && currentServerTimeNode != null)
+            if (this.IsSessionOpen)
             {
-                return (DateTime)currentServerTimeNode.Value;
-
+                return (DateTime?)this.opcClientService.ReadNode(Opc.Ua.Variables.Server_ServerStatus_CurrentTime)?.Value;
             }
 
             return null;
@@ -199,9 +196,8 @@ namespace DEHPEcosimPro.DstController
         /// Calls the specified method and returns the output arguments.
         /// </summary>
         /// <param name="methodBrowseName">The BrowseName of the server method</param>
-        /// <param name="arguments">The arguments to input</param>
         /// <returns>The <see cref="IList{T}"/> of output argument values, or null if the no method was found with the provided BrowseName</returns>
-        public IList<object> CallServerMethod(string methodBrowseName, params object[] arguments)
+        public IList<object> CallServerMethod(string methodBrowseName)
         {
             var serverMethodsNode = this.References.SingleOrDefault(r => r.BrowseName.Name == "server_methods")?.NodeId;
             var methodNode = this.Methods.SingleOrDefault(m => m.BrowseName.Name == methodBrowseName)?.NodeId;

--- a/DEHPEcosimPro/DstController/IDstController.cs
+++ b/DEHPEcosimPro/DstController/IDstController.cs
@@ -106,9 +106,8 @@ namespace DEHPEcosimPro.DstController
         /// Calls the specified method and returns the output arguments.
         /// </summary>
         /// <param name="methodBrowseName">The BrowseName of the server method</param>
-        /// <param name="arguments">The arguments to input</param>
         /// <returns>The <see cref="IList{T}"/> of output argument values, or null if the no method was found with the provided BrowseName</returns>
-        IList<object> CallServerMethod(string methodBrowseName, params object[] arguments);
+        IList<object> CallServerMethod(string methodBrowseName);
 
         /// <summary>
         /// Removes all active subscriptions from the session.

--- a/DEHPEcosimPro/DstController/IDstController.cs
+++ b/DEHPEcosimPro/DstController/IDstController.cs
@@ -28,6 +28,8 @@ namespace DEHPEcosimPro.DstController
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
+    using DEHPEcosimPro.Services.OpcConnector;
+
     using Opc.Ua;
     using Opc.Ua.Client;
 
@@ -37,7 +39,7 @@ namespace DEHPEcosimPro.DstController
     public interface IDstController
     {
         /// <summary>
-        /// Assert whether the <see cref="Services.OpcConnector.OpcSessionHandler.Session"/> is Open
+        /// Assert whether the <see cref="OpcSessionHandler.OpcSession"/> is Open
         /// </summary>
         bool IsSessionOpen { get; set; }
 
@@ -101,12 +103,20 @@ namespace DEHPEcosimPro.DstController
         void AddSubscription(ReferenceDescription reference);
 
         /// <summary>
+        /// Calls the specified method and returns the output arguments.
+        /// </summary>
+        /// <param name="methodBrowseName">The BrowseName of the server method</param>
+        /// <param name="arguments">The arguments to input</param>
+        /// <returns>The <see cref="IList{T}"/> of output argument values, or null if the no method was found with the provided BrowseName</returns>
+        IList<object> CallServerMethod(string methodBrowseName, params object[] arguments);
+
+        /// <summary>
         /// Removes all active subscriptions from the session.
         /// </summary>
         void ClearSubscriptions();
 
         /// <summary>
-        /// Closes the <see cref="Services.OpcConnector.OpcSessionHandler.Session"/>
+        /// Closes the <see cref="OpcSessionHandler.OpcSession"/>
         /// </summary>
         void CloseSession();
     }

--- a/DEHPEcosimPro/DstController/IDstController.cs
+++ b/DEHPEcosimPro/DstController/IDstController.cs
@@ -24,6 +24,7 @@
 
 namespace DEHPEcosimPro.DstController
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
@@ -39,6 +40,16 @@ namespace DEHPEcosimPro.DstController
         /// Assert whether the <see cref="Services.OpcConnector.OpcSessionHandler.Session"/> is Open
         /// </summary>
         bool IsSessionOpen { get; set; }
+
+        /// <summary>
+        /// The endpoint url of the currently open session
+        /// </summary>
+        string ServerAddress { get; }
+
+        /// <summary>
+        /// The refresh interval for subscriptions in milliseconds
+        /// </summary>
+        int RefreshInterval { get; }
 
         /// <summary>
         /// Gets the references variables available from the connected OPC server
@@ -63,6 +74,25 @@ namespace DEHPEcosimPro.DstController
         /// <param name="credential">The <see cref="IUserIdentity"/> default = null in case server does not require authentication</param>
         /// <returns>A <see cref="Task"/></returns>
         Task Connect(string endpoint, bool autoAcceptConnection = true, IUserIdentity credential = null);
+
+        /// <summary>
+        /// Reads and returns the server start time, in UTC, of the currently open session
+        /// </summary>
+        /// <returns>null if the session is closed or the ServerStatus.StartTime node was not found</returns>
+        DateTime? GetServerStartTime();
+
+        /// <summary>
+        /// Reads and returns the current server time, in UTC, of the currently open session
+        /// </summary>
+        /// <returns>null if the session is closed or the ServerStatus.CurrentTime node was not found</returns>
+
+        DateTime? GetCurrentServerTime();
+
+        /// <summary>
+        /// Adds one subscription for the <paramref name="nodeId"/>
+        /// </summary>
+        /// <param name="nodeId">The <see cref="NodeId"/></param>
+        public void AddSubscription(NodeId nodeId);
 
         /// <summary>
         /// Adds one subscription for the <paramref name="reference"/>

--- a/DEHPEcosimPro/Services/OpcConnector/Interfaces/IOpcClientService.cs
+++ b/DEHPEcosimPro/Services/OpcConnector/Interfaces/IOpcClientService.cs
@@ -38,7 +38,12 @@ namespace DEHPEcosimPro.Services.OpcConnector.Interfaces
     public interface IOpcClientService
     {
         /// <summary>
-        /// The refresh interval for subscriptions in millisecond
+        /// The endpoint url
+        /// </summary>
+        string EndpointUrl { get; }
+
+        /// <summary>
+        /// The refresh interval for subscriptions in milliseconds
         /// </summary>
         int RefreshInterval { get; set; }
 

--- a/DEHPEcosimPro/Services/OpcConnector/Interfaces/IOpcSessionHandler.cs
+++ b/DEHPEcosimPro/Services/OpcConnector/Interfaces/IOpcSessionHandler.cs
@@ -36,9 +36,9 @@ namespace DEHPEcosimPro.Services.OpcConnector.Interfaces
     public interface IOpcSessionHandler
     {
         /// <summary>
-        /// Gets the <see cref="Opc.Ua.Client.Session"/>
+        /// Gets the OPC <see cref="Opc.Ua.Client.Session"/>
         /// </summary>
-        Session Session { get; }
+        Session OpcSession { get; }
 
         /// <summary>
         /// Gets or Sets the default subscription for the session.
@@ -139,7 +139,7 @@ namespace DEHPEcosimPro.Services.OpcConnector.Interfaces
         void SetSession(IOpcSessionReconnectHandler reconnectHandler);
 
         /// <summary>
-        /// Closes the <see cref="OpcSessionHandler.Session"/> and deletes subscription
+        /// Closes the <see cref="OpcSessionHandler.OpcSession"/> and deletes subscription
         /// </summary>
         /// <param name="deleteSubscription">An assert whether to delete subscriptions</param>
         void CloseSession(bool deleteSubscription = true);

--- a/DEHPEcosimPro/Services/OpcConnector/OpcClientService.cs
+++ b/DEHPEcosimPro/Services/OpcConnector/OpcClientService.cs
@@ -77,17 +77,17 @@ namespace DEHPEcosimPro.Services.OpcConnector
         private readonly IOpcSessionReconnectHandler reconnectHandler;
 
         /// <summary>
-        /// The endpoint url
-        /// </summary>
-        private string endpointUrl;
-
-        /// <summary>
         /// An assert whether the certificate should be auto accepted
         /// </summary>
         private bool autoAccept;
-            
+
         /// <summary>
-        /// The refresh interval for subscriptions in millisecond
+        /// The endpoint url
+        /// </summary>
+        public string EndpointUrl { get; private set; }
+
+        /// <summary>
+        /// The refresh interval for subscriptions in milliseconds
         /// </summary>
         public int RefreshInterval { get; set; } = 1000;
 
@@ -132,7 +132,7 @@ namespace DEHPEcosimPro.Services.OpcConnector
         /// <returns>A <see cref="Task"/></returns>
         public async Task Connect(string endpoint, bool autoAcceptConnection = true, IUserIdentity credential = null)
         {
-            this.endpointUrl = endpoint;
+            this.EndpointUrl = endpoint;
             this.autoAccept = autoAcceptConnection;
 
             try
@@ -157,11 +157,11 @@ namespace DEHPEcosimPro.Services.OpcConnector
             this.sessionHandler.CloseSession();
             this.References.Clear();
             this.OpcClientStatusCode = OpcClientStatusCode.Disconnected;
-            this.statusBarControl.Append($"Session from {this.endpointUrl} has been closed", StatusBarMessageSeverity.Warning);
+            this.statusBarControl.Append($"Session from {this.EndpointUrl} has been closed", StatusBarMessageSeverity.Warning);
         }
 
         /// <summary>
-        /// Opens a connection to the <see cref="endpointUrl"/>
+        /// Opens a connection to the <see cref="EndpointUrl"/>
         /// </summary>
         /// <param name="credential">The <see cref="IUserIdentity"/> to use to authenticate the connection</param>
         /// <returns>A <see cref="Task"/></returns>
@@ -172,7 +172,9 @@ namespace DEHPEcosimPro.Services.OpcConnector
 
             var application = new ApplicationInstance
             {
-                ApplicationName = "DEPHEcosimPro OPC-UA Client", ApplicationType = ApplicationType.Client, ConfigSectionName = "Resources/OpcClient"
+                ApplicationName = "DEPHEcosimPro OPC-UA Client",
+                ApplicationType = ApplicationType.Client,
+                ConfigSectionName = "Resources/OpcClient"
             };
 
             var configuration = await application.LoadApplicationConfiguration(false);
@@ -192,9 +194,9 @@ namespace DEHPEcosimPro.Services.OpcConnector
 
             configuration.CertificateValidator.CertificateValidation += this.CertificateValidator;
 
-            this.statusBarControl.Append($"Discovering endpoints of {this.endpointUrl}");
+            this.statusBarControl.Append($"Discovering endpoints of {this.EndpointUrl}");
             this.OpcClientStatusCode = OpcClientStatusCode.ErrorDiscoverEndpoints;
-            var selectedEndpoint = this.sessionHandler.SelectEndpoint(this.endpointUrl);
+            var selectedEndpoint = this.sessionHandler.SelectEndpoint(this.EndpointUrl);
 
             Logger.Info($"Selected endpoint uses: {selectedEndpoint.SecurityPolicyUri.Substring(selectedEndpoint.SecurityPolicyUri.LastIndexOf('#') + 1)}");
 
@@ -213,7 +215,7 @@ namespace DEHPEcosimPro.Services.OpcConnector
             this.References = this.sessionHandler.FetchReferences(ObjectIds.ObjectsFolder);
 
             this.sessionHandler.Browse(ObjectIds.ObjectsFolder, ReferenceTypeIds.HierarchicalReferences, true,
-                (uint) NodeClass.Variable | (uint) NodeClass.Object | (uint) NodeClass.Method, out _, out var references);
+                (uint)NodeClass.Variable | (uint)NodeClass.Object | (uint)NodeClass.Method, out _, out var references);
 
             this.References = references;
             var additionalReferences = new ReferenceDescriptionCollection();
@@ -223,8 +225,8 @@ namespace DEHPEcosimPro.Services.OpcConnector
                 this.statusBarControl.Append($"{reference.DisplayName}, {reference.BrowseName}, {reference.NodeClass}");
 
                 this.sessionHandler.Browse(ExpandedNodeId.ToNodeId(reference.NodeId, this.sessionHandler.NamespaceUris),
-                    ReferenceTypeIds.HierarchicalReferences, true, 
-                    (uint) NodeClass.Variable | (uint) NodeClass.Object | (uint) NodeClass.Method, out _, out var referenceDescriptions);
+                    ReferenceTypeIds.HierarchicalReferences, true,
+                    (uint)NodeClass.Variable | (uint)NodeClass.Object | (uint)NodeClass.Method, out _, out var referenceDescriptions);
 
                 additionalReferences.AddRange(referenceDescriptions);
 
@@ -278,7 +280,7 @@ namespace DEHPEcosimPro.Services.OpcConnector
             {
                 new MonitoredItem(subscription.DefaultItem)
                 {
-                    DisplayName = nodeId.Identifier.ToString(), StartNodeId = nodeId, SamplingInterval = this.RefreshInterval   
+                    DisplayName = nodeId.Identifier.ToString(), StartNodeId = nodeId, SamplingInterval = this.RefreshInterval
                 }
             };
 
@@ -327,7 +329,7 @@ namespace DEHPEcosimPro.Services.OpcConnector
         {
             return this.sessionHandler.ReadNode(nodeId);
         }
-        
+
         /// <summary>
         /// The <see cref="KeepAliveEventHandler"/> that is used to keep the <see cref="Opc.Ua.Client.Session"/> alive
         /// </summary>
@@ -397,7 +399,7 @@ namespace DEHPEcosimPro.Services.OpcConnector
             {
                 return;
             }
-            
+
             e.Accept = this.autoAccept;
 
             this.statusBarControl.Append(this.autoAccept ? $"Accepted Certificate: {e.Certificate.Subject}" : $"Rejected Certificate: {e.Certificate.Subject}");

--- a/DEHPEcosimPro/Services/OpcConnector/OpcClientService.cs
+++ b/DEHPEcosimPro/Services/OpcConnector/OpcClientService.cs
@@ -237,41 +237,12 @@ namespace DEHPEcosimPro.Services.OpcConnector
             }
 
             this.References.AddRange(additionalReferences);
-            this.AddSubscription();
-        }
-
-        /// <summary>
-        /// Creates the default subscription which monitors the server time
-        /// </summary>
-        private void AddSubscription()
-        {
-            var subscription = new Subscription(this.sessionHandler.DefaultSubscription);
-
-            var list = new List<MonitoredItem>
-            {
-                new MonitoredItem(subscription.DefaultItem)
-                {
-                    DisplayName = "ServerStatusCurrentTime", StartNodeId = $"i={Variables.Server_ServerStatus_CurrentTime}"
-                }
-            };
-
-            list.ForEach(i => i.Notification += (item, e) =>
-            {
-                foreach (var value in item.DequeueValues())
-                {
-                    this.statusBarControl.Append($"{item.DisplayName}: {value.Value}, {value.SourceTimestamp}, {value.StatusCode}, {e.NotificationValue.TypeId}");
-                }
-            });
-
-            subscription.AddItems(list);
-            this.AddSubscription(subscription);
         }
 
         /// <summary>
         /// Adds a subscription based on the nodeId to monitor
         /// </summary>
         /// <param name="nodeId">The the <see cref="NodeId"/> to monitor</param>
-        /// <param name="onNotification">A event handler to call back on Notification</param>
         public void AddSubscription(NodeId nodeId)
         {
             var subscription = new Subscription(this.sessionHandler.DefaultSubscription);

--- a/DEHPEcosimPro/Services/OpcConnector/OpcSessionHandler.cs
+++ b/DEHPEcosimPro/Services/OpcConnector/OpcSessionHandler.cs
@@ -46,23 +46,23 @@ namespace DEHPEcosimPro.Services.OpcConnector
         private readonly IList<Subscription> subscriptions = new List<Subscription>();
 
         /// <summary>
-        /// Gets the <see cref="Opc.Ua.Client.Session"/>
+        /// Gets the OPC <see cref="Opc.Ua.Client.Session"/>
         /// </summary>
-        public Session Session { get; private set; }
+        public Session OpcSession { get; private set; }
         
         /// <summary>
         /// Gets or Sets the default subscription for the session.
         /// </summary>
         public Subscription DefaultSubscription
         {
-            get => this.Session.DefaultSubscription;
-            set => this.Session.DefaultSubscription = value;
+            get => this.OpcSession.DefaultSubscription;
+            set => this.OpcSession.DefaultSubscription = value;
         }
 
         /// <summary>
         /// Gets the table of namespace uris known to the server.
         /// </summary>
-        public NamespaceTable NamespaceUris => this.Session.NamespaceUris;
+        public NamespaceTable NamespaceUris => this.OpcSession.NamespaceUris;
 
         /// <summary>
         /// Returns true if the session is not receiving keep alives.
@@ -71,7 +71,7 @@ namespace DEHPEcosimPro.Services.OpcConnector
         /// Set to true if the server does not respond for 2 times the KeepAliveInterval.
         /// Set to false is communication recovers.
         /// </remarks>
-        public bool KeepAliveStopped => this.Session.KeepAliveStopped;
+        public bool KeepAliveStopped => this.OpcSession.KeepAliveStopped;
 
         /// <summary>
         /// Raised when a keep alive arrives from the server or an error is detected.
@@ -83,8 +83,8 @@ namespace DEHPEcosimPro.Services.OpcConnector
         /// </remarks>
         public event KeepAliveEventHandler KeepAlive
         {
-            add => this.Session.KeepAlive += value;
-            remove => this.Session.KeepAlive -= value;
+            add => this.OpcSession.KeepAlive += value;
+            remove => this.OpcSession.KeepAlive -= value;
         }
     
         /// <summary>
@@ -94,7 +94,7 @@ namespace DEHPEcosimPro.Services.OpcConnector
         /// <returns>A <see cref="ReferenceDescriptionCollection"/></returns>
         public ReferenceDescriptionCollection FetchReferences(NodeId nodeId)
         {
-            return this.Session.FetchReferences(nodeId);
+            return this.OpcSession.FetchReferences(nodeId);
         }
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace DEHPEcosimPro.Services.OpcConnector
         public void Browse(NodeId nodeToBrowse, NodeId referenceTypeId, bool includeSubtypes, 
             uint nodeClassMask, out byte[] continuationPoint, out ReferenceDescriptionCollection references)
         {
-            this.Session.Browse(null, null, nodeToBrowse, 0u, BrowseDirection.Forward, referenceTypeId,
+            this.OpcSession.Browse(null, null, nodeToBrowse, 0u, BrowseDirection.Forward, referenceTypeId,
                 includeSubtypes, nodeClassMask, out continuationPoint, out references);
         }
 
@@ -128,7 +128,7 @@ namespace DEHPEcosimPro.Services.OpcConnector
         public async Task CreateSession(ApplicationConfiguration configuration, ConfiguredEndpoint endpoint, bool updateBeforeConnect, string sessionName,
             uint sessionTimeout, IUserIdentity identity, IList<string> preferredLocales)
         {
-            this.Session = await Session.Create(configuration, endpoint, updateBeforeConnect, sessionName, sessionTimeout, identity, preferredLocales);
+            this.OpcSession = await Session.Create(configuration, endpoint, updateBeforeConnect, sessionName, sessionTimeout, identity, preferredLocales);
         }
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace DEHPEcosimPro.Services.OpcConnector
         /// <returns>An assert whether the removal whent ok</returns>
         public bool AddSubscription(Subscription subscription)
         {
-            var result = this.Session.AddSubscription(subscription);
+            var result = this.OpcSession.AddSubscription(subscription);
             subscription.Create();
             return result;
         }
@@ -150,7 +150,7 @@ namespace DEHPEcosimPro.Services.OpcConnector
         /// <returns>An assert whether the removal went ok</returns>
         public bool RemoveSubscription(Subscription subscription)
         {
-            if (this.Session.RemoveSubscription(subscription))
+            if (this.OpcSession.RemoveSubscription(subscription))
             {
                 this.subscriptions.Remove(subscription);
                 return true;
@@ -165,7 +165,7 @@ namespace DEHPEcosimPro.Services.OpcConnector
         /// <returns>An assert whether the removal went ok</returns>
         public bool ClearSubscriptions()
         {
-            var result = this.Session?.RemoveSubscriptions(this.subscriptions) == true;
+            var result = this.OpcSession?.RemoveSubscriptions(this.subscriptions) == true;
             
             if (result)
             {
@@ -184,7 +184,7 @@ namespace DEHPEcosimPro.Services.OpcConnector
         /// <returns>The <see cref="IList{T}"/> of output argument values.</returns>
         public IList<object> CallMethod(NodeId objectId, NodeId methodId, params object[] arguments)
         {
-            return this.Session.Call(objectId, methodId, arguments);
+            return this.OpcSession.Call(objectId, methodId, arguments);
         }
 
         /// <summary>
@@ -193,16 +193,16 @@ namespace DEHPEcosimPro.Services.OpcConnector
         /// <param name="reconnectHandler">A <see cref="IOpcSessionReconnectHandler"/></param>
         public void SetSession(IOpcSessionReconnectHandler reconnectHandler)
         {
-            this.Session = reconnectHandler?.Session;
+            this.OpcSession = reconnectHandler?.Session;
         }
 
         /// <summary>
-        /// Closes the <see cref="Session"/> and deletes subscription
+        /// Closes the <see cref="OpcSession"/> and deletes subscription
         /// </summary>
         /// <param name="deleteSubscription">An assert whether to delete subscriptions</param>
         public void CloseSession(bool deleteSubscription = true)
         {
-            this.Session?.Close();
+            this.OpcSession?.Close();
         }
 
         /// <summary>
@@ -212,7 +212,7 @@ namespace DEHPEcosimPro.Services.OpcConnector
         /// <returns>The <see cref="DataValue"/></returns>
         public DataValue ReadNode(NodeId nodeId)
         {
-            return this.Session.ReadValue(nodeId);
+            return this.OpcSession.ReadValue(nodeId);
         }
 
         /// <summary>

--- a/DEHPEcosimPro/ViewModel/DstBrowserHeaderViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/DstBrowserHeaderViewModel.cs
@@ -45,6 +45,11 @@ namespace DEHPEcosimPro.ViewModel
     public class DstBrowserHeaderViewModel : ReactiveObject, IDstBrowserHeaderViewModel
     {
         /// <summary>
+        /// The <see cref="NodeId"/> of the ServerStatus.CurrentTime node in an OPC session
+        /// </summary>
+        private readonly NodeId currentServerTimeNodeId = new NodeId(Variables.Server_ServerStatus_CurrentTime);
+
+        /// <summary>
         /// The <see cref="IDstController"/>
         /// </summary>
         private readonly IDstController dstController;
@@ -60,32 +65,9 @@ namespace DEHPEcosimPro.ViewModel
         private string serverAddress;
 
         /// <summary>
-        /// The <see cref="NodeId"/> of the ServerStatus.CurrentTime node in an OPC session
-        /// </summary>
-        private readonly NodeId currentServerTimeNodeId = new NodeId(Variables.Server_ServerStatus_CurrentTime);
-
-        /// <summary>
-        /// Gets or sets the URI of the connected data source
-        /// </summary>
-        public string ServerAddress
-        {
-            get => this.serverAddress;
-            set => this.RaiseAndSetIfChanged(ref this.serverAddress, value);
-        }
-
-        /// <summary>
         /// Backing field for <see cref="SamplingInterval"/>
         /// </summary>
         private int samplingInterval;
-
-        /// <summary>
-        /// Gets or sets the time, in milliseconds, between which data is recorded
-        /// </summary>
-        public int SamplingInterval
-        {
-            get => this.samplingInterval;
-            set => this.RaiseAndSetIfChanged(ref this.samplingInterval, value);
-        }
 
         /// <summary>
         /// Backing field for <see cref="VariablesCount"/>
@@ -93,51 +75,14 @@ namespace DEHPEcosimPro.ViewModel
         private int variablesCount;
 
         /// <summary>
-        /// Gets or sets the total number of variables in the open session
-        /// </summary>
-        public int VariablesCount
-        {
-            get => this.variablesCount;
-            set => this.RaiseAndSetIfChanged(ref this.variablesCount, value);
-        }
-
-        /// <summary>
         /// Backing field for <see cref="ServerStartTime"/> 
         /// </summary>
         private DateTime? serverStartTime;
 
         /// <summary>
-        /// Gets or sets the date and time, in UTC, from which the server has been up and running
-        /// </summary>
-        public DateTime? ServerStartTime
-        {
-            get => this.serverStartTime;
-            set => this.RaiseAndSetIfChanged(ref this.serverStartTime, value);
-        }
-
-        /// <summary>
         /// Backing field for <see cref="CurrentServerTime"/> 
         /// </summary>
         private DateTime? currentServerTime;
-
-        /// <summary>
-        /// Gets or sets the current date/time, in UTC, of the server
-        /// </summary>
-        public DateTime? CurrentServerTime
-        {
-            get => this.currentServerTime;
-            set => this.RaiseAndSetIfChanged(ref this.currentServerTime, value);
-        }
-
-        /// <summary>
-        /// <see cref="ReactiveCommand{T}"/> for calling the 'Run' server method
-        /// </summary>
-        public ReactiveCommand<object> CallRunMethodCommand { get; set; }
-
-        /// <summary>
-        /// <see cref="ReactiveCommand{T}"/> for calling the 'Reset' server method
-        /// </summary>
-        public ReactiveCommand<object> CallResetMethodCommand { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DstBrowserHeaderViewModel"/>
@@ -162,6 +107,61 @@ namespace DEHPEcosimPro.ViewModel
             this.CallResetMethodCommand = ReactiveCommand.Create(canCallServerMethods);
             this.CallResetMethodCommand.Subscribe(_ => this.CallServerMethod("method_reset"));
         }
+
+        /// <summary>
+        /// Gets or sets the URI of the connected data source
+        /// </summary>
+        public string ServerAddress
+        {
+            get => this.serverAddress;
+            set => this.RaiseAndSetIfChanged(ref this.serverAddress, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the time, in milliseconds, between which data is recorded
+        /// </summary>
+        public int SamplingInterval
+        {
+            get => this.samplingInterval;
+            set => this.RaiseAndSetIfChanged(ref this.samplingInterval, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the total number of variables in the open session
+        /// </summary>
+        public int VariablesCount
+        {
+            get => this.variablesCount;
+            set => this.RaiseAndSetIfChanged(ref this.variablesCount, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the date and time, in UTC, from which the server has been up and running
+        /// </summary>
+        public DateTime? ServerStartTime
+        {
+            get => this.serverStartTime;
+            set => this.RaiseAndSetIfChanged(ref this.serverStartTime, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the current date/time, in UTC, of the server
+        /// </summary>
+        public DateTime? CurrentServerTime
+        {
+            get => this.currentServerTime;
+            set => this.RaiseAndSetIfChanged(ref this.currentServerTime, value);
+        }
+
+        /// <summary>
+        /// <see cref="ReactiveCommand{T}"/> for calling the 'Run' server method
+        /// </summary>
+        public ReactiveCommand<object> CallRunMethodCommand { get; set; }
+
+        /// <summary>
+        /// <see cref="ReactiveCommand{T}"/> for calling the 'Reset' server method
+        /// </summary>
+        public ReactiveCommand<object> CallResetMethodCommand { get; set; }
 
         /// <summary>
         /// Updates the view model's properties
@@ -204,6 +204,7 @@ namespace DEHPEcosimPro.ViewModel
             try
             {
                 var callMethodResult = this.dstController.CallServerMethod(methodBrowseName);
+
                 if (callMethodResult != null)
                 {
                     this.statusBarControlViewModel.Append($"Method executed successfully. {string.Join(", ", callMethodResult)}");

--- a/DEHPEcosimPro/ViewModel/DstBrowserHeaderViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/DstBrowserHeaderViewModel.cs
@@ -24,6 +24,8 @@
 
 namespace DEHPEcosimPro.ViewModel
 {
+    using System;
+
     using DEHPEcosimPro.DstController;
     using DEHPEcosimPro.ViewModel.Interfaces;
     using DEHPEcosimPro.Views;
@@ -40,9 +42,77 @@ namespace DEHPEcosimPro.ViewModel
         /// </summary>
         private readonly IDstController dstController;
 
+        /// <summary>
+        /// Backing field for <see cref="ServerAddress"/>
+        /// </summary>
+        private string serverAddress;
+
+        /// <summary>
+        /// Gets or sets the URI of the connected data source
+        /// </summary>
+        public string ServerAddress
+        {
+            get => this.serverAddress;
+            set => this.serverAddress = value;
+        }
+
+        /// <summary>
+        /// Backing field for <see cref="SamplingInterval"/>
+        /// </summary>
+        private int samplingInterval;
+
+        /// <summary>
+        /// Gets or sets the time, in milliseconds, between which data is recorded
+        /// </summary>
+        public int SamplingInterval
+        {
+            get => this.samplingInterval;
+            set => this.samplingInterval = value;
+        }
+
+        /// <summary>
+        /// Backing field for <see cref="VariablesCount"/>
+        /// </summary>
+        private int variablesCount;
+
+        /// <summary>
+        /// Gets or sets the total number of variables in the open session
+        /// </summary>
+        public int VariablesCount
+        {
+            get => this.variablesCount;
+            set => this.variablesCount = value;
+        }
+
+        /// <summary>
+        /// Backing field for <see cref="ServerUpFrom"/> 
+        /// </summary>
+        private DateTime serverUpFrom;
+
+        /// <summary>
+        /// Gets or sets the date and time from which the server has been up and running
+        /// </summary>
+        public DateTime ServerUpFrom
+        {
+            get => this.serverUpFrom;
+            set => this.serverUpFrom = value;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DstBrowserHeaderViewModel"/>
+        /// </summary>
+        /// <param name="dstController">The <see cref="IDstController"/></param>
         public DstBrowserHeaderViewModel(IDstController dstController)
         {
             this.dstController = dstController;
+        }
+
+        /// <summary>
+        /// Updates the view model's properties
+        /// </summary>
+        private void UpdateProperties()
+        {
+
         }
     }
 }

--- a/DEHPEcosimPro/ViewModel/DstBrowserHeaderViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/DstBrowserHeaderViewModel.cs
@@ -2,7 +2,7 @@
 // <copyright file="DstBrowserHeaderViewModel.cs" company="RHEA System S.A.">
 //    Copyright (c) 2020-2020 RHEA System S.A.
 // 
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
 // 
 //    This file is part of DEHPEcosimPro
 // 
@@ -24,13 +24,25 @@
 
 namespace DEHPEcosimPro.ViewModel
 {
+    using DEHPEcosimPro.DstController;
     using DEHPEcosimPro.ViewModel.Interfaces;
     using DEHPEcosimPro.Views;
 
+    using ReactiveUI;
+
     /// <summary>
-    /// The <see cref="DstBrowserHeaderViewModel"/> is the view model the <see cref="DstBrowserHeader"/>
+    /// The view model for <see cref="DstBrowserHeader"/>
     /// </summary>
-    public class DstBrowserHeaderViewModel : IDstBrowserHeaderViewModel
+    public class DstBrowserHeaderViewModel : ReactiveObject, IDstBrowserHeaderViewModel
     {
+        /// <summary>
+        /// The <see cref="IDstController"/>
+        /// </summary>
+        private readonly IDstController dstController;
+
+        public DstBrowserHeaderViewModel(IDstController dstController)
+        {
+            this.dstController = dstController;
+        }
     }
 }

--- a/DEHPEcosimPro/ViewModel/DstBrowserHeaderViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/DstBrowserHeaderViewModel.cs
@@ -96,7 +96,7 @@ namespace DEHPEcosimPro.ViewModel
 
             this.WhenAnyValue(x => x.dstController.IsSessionOpen).Subscribe(_ => this.UpdateProperties());
 
-            CDPMessageBus.Current.Listen<OpcVariableChangedEvent>().Where(x => x.Id == this.currentServerTimeNodeId.Identifier)
+            CDPMessageBus.Current.Listen<OpcVariableChangedEvent>().Where(x => Equals(x.Id, this.currentServerTimeNodeId.Identifier))
                 .Subscribe(e => this.CurrentServerTime = (DateTime)e.Value);
 
             var canCallServerMethods = this.WhenAnyValue(vm => vm.dstController.IsSessionOpen);

--- a/DEHPEcosimPro/ViewModel/Interfaces/IDstBrowserHeaderViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/Interfaces/IDstBrowserHeaderViewModel.cs
@@ -26,6 +26,8 @@ namespace DEHPEcosimPro.ViewModel.Interfaces
 {
     using System;
 
+    using ReactiveUI;
+
     /// <summary>
     /// Interface definition for <see cref="DstBrowserHeaderViewModel"/>
     /// </summary>
@@ -55,5 +57,15 @@ namespace DEHPEcosimPro.ViewModel.Interfaces
         /// Gets or sets the current date/time of the server
         /// </summary>
         DateTime? CurrentServerTime { get; set; }
+
+        /// <summary>
+        /// <see cref="ReactiveCommand{T}"/> for calling the 'Run' server method
+        /// </summary>
+        ReactiveCommand<object> CallRunMethodCommand { get; set; }
+
+        /// <summary>
+        /// <see cref="ReactiveCommand{T}"/> for calling the 'Reset' server method
+        /// </summary>
+        ReactiveCommand<object> CallResetMethodCommand { get; set; }
     }
 }

--- a/DEHPEcosimPro/ViewModel/Interfaces/IDstBrowserHeaderViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/Interfaces/IDstBrowserHeaderViewModel.cs
@@ -49,6 +49,11 @@ namespace DEHPEcosimPro.ViewModel.Interfaces
         /// <summary>
         /// Gets or sets the date/time from which the server is up
         /// </summary>
-        DateTime ServerUpFrom { get; set; }
+        DateTime? ServerStartTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current date/time of the server
+        /// </summary>
+        DateTime? CurrentServerTime { get; set; }
     }
 }

--- a/DEHPEcosimPro/ViewModel/Interfaces/IDstBrowserHeaderViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/Interfaces/IDstBrowserHeaderViewModel.cs
@@ -24,10 +24,31 @@
 
 namespace DEHPEcosimPro.ViewModel.Interfaces
 {
+    using System;
+
     /// <summary>
     /// Interface definition for <see cref="DstBrowserHeaderViewModel"/>
     /// </summary>
     public interface IDstBrowserHeaderViewModel
     {
+        /// <summary>
+        /// Gets or sets the URI of the connected data source
+        /// </summary>
+        string ServerAddress { get; set; }
+
+        /// <summary>
+        /// Gets or sets the time, in milliseconds, between which data is recorded
+        /// </summary>
+        int SamplingInterval { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total number of variables in the open session
+        /// </summary>
+        int VariablesCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date/time from which the server is up
+        /// </summary>
+        DateTime ServerUpFrom { get; set; }
     }
 }

--- a/DEHPEcosimPro/Views/DstBrowserHeader.xaml
+++ b/DEHPEcosimPro/Views/DstBrowserHeader.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:views="clr-namespace:DEHPEcosimPro.Views" 
-             d:DesignHeight="60" d:DesignWidth="400" mc:Ignorable="d">
+             d:DesignHeight="100" d:DesignWidth="400" mc:Ignorable="d">
     <UserControl.ToolTip>
         <ToolTip>
             <StackPanel Orientation="Vertical">
@@ -37,12 +37,13 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
             <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
 
         <TextBlock Grid.Row="0" Grid.Column="0" Height="Auto" Margin="3" FontSize="10" FontWeight="Bold" Text="Server Address: " />
@@ -59,5 +60,8 @@
 
         <TextBlock Grid.Row="2" Grid.Column="2" Height="Auto" Margin="6,3,3,3" FontSize="10" FontWeight="Bold" Text="Current Server Time: " />
         <TextBlock Grid.Row="2" Grid.Column="3" Height="Auto" Margin="3" FontSize="10" TextTrimming="CharacterEllipsis" Text="{Binding CurrentServerTime}"/>
+
+        <Button Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Height="35" Margin="3" HorizontalAlignment="Stretch" Content="Run" ToolTip="Call Run Method" Command="{Binding CallRunMethodCommand}"/>
+        <Button Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2" Height="35" Margin="3" HorizontalAlignment="Stretch" Content="Reset" ToolTip="Call Reset Method" Command="{Binding CallResetMethodCommand}"/>
     </Grid>
 </UserControl>

--- a/DEHPEcosimPro/Views/DstBrowserHeader.xaml
+++ b/DEHPEcosimPro/Views/DstBrowserHeader.xaml
@@ -10,24 +10,24 @@
         <ToolTip>
             <StackPanel Orientation="Vertical">
                 <StackPanel Margin="3" Orientation="Horizontal">
-                    <TextBlock FontWeight="Bold" Text="Model:" />
-                    <TextBlock Margin="3,0,0,0" />
+                    <TextBlock FontWeight="Bold" Text="Server Address:" />
+                    <TextBlock Margin="3,0,0,0" Text="{Binding ServerAddress}" />
                 </StackPanel>
                 <StackPanel Margin="3" Orientation="Horizontal">
-                    <TextBlock FontWeight="Bold" Text="Iteration:" />
-                    <TextBlock Margin="3,0,0,0" />
+                    <TextBlock FontWeight="Bold" Text="Sampling Interval (ms):" />
+                    <TextBlock Margin="3,0,0,0" Text="{Binding SamplingInterval}"/>
                 </StackPanel>
                 <StackPanel Margin="3" Orientation="Horizontal">
-                    <TextBlock FontWeight="Bold" Text="Person:" />
-                    <TextBlock />
+                    <TextBlock FontWeight="Bold" Text="Number of Variables:" />
+                    <TextBlock Margin="3,0,0,0" Text="{Binding VariablesCount}"/>
                 </StackPanel>
                 <StackPanel Margin="3" Orientation="Horizontal">
-                    <TextBlock FontWeight="Bold" Text="Domain of Expertise:" />
-                    <TextBlock Margin="3,0,0,0" />
+                    <TextBlock FontWeight="Bold" Text="Server Start Time:" />
+                    <TextBlock Margin="3,0,0,0" Text="{Binding ServerStartTime}"/>
                 </StackPanel>
                 <StackPanel Margin="3" Orientation="Horizontal">
-                    <TextBlock FontWeight="Bold" Text="Source:" />
-                    <TextBlock Margin="3,0,0,0" Text="{Binding DataSource}" />
+                    <TextBlock FontWeight="Bold" Text="Current Server Time:" />
+                    <TextBlock Margin="3,0,0,0" Text="{Binding CurrentServerTime}"/>
                 </StackPanel>
             </StackPanel>
         </ToolTip>
@@ -45,19 +45,19 @@
             <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
 
-        <TextBlock Grid.Row="0" Grid.Column="0" Height="Auto" Margin="3" FontSize="10" FontWeight="Bold" Text="Model: " />
-        <TextBlock Grid.Row="0" Grid.Column="1" Height="Auto" Margin="3" FontSize="10" TextTrimming="CharacterEllipsis" />
+        <TextBlock Grid.Row="0" Grid.Column="0" Height="Auto" Margin="3" FontSize="10" FontWeight="Bold" Text="Server Address: " />
+        <TextBlock Grid.Row="0" Grid.Column="1" Height="Auto" Margin="3" FontSize="10" TextTrimming="CharacterEllipsis" Text="{Binding ServerAddress}" />
 
-        <TextBlock Grid.Row="0" Grid.Column="2" Height="Auto" Margin="6,3,3,3" FontSize="10" FontWeight="Bold" Text="Data-Source:" />
-        <TextBlock Grid.Row="0" Grid.Column="3" Height="Auto" Margin="3" FontSize="10" Text="{Binding DataSource}" TextTrimming="CharacterEllipsis" />
+        <TextBlock Grid.Row="0" Grid.Column="2" Height="Auto" Margin="6,3,3,3" FontSize="10" FontWeight="Bold" Text="Sampling Interval (ms): " />
+        <TextBlock Grid.Row="0" Grid.Column="3" Height="Auto" Margin="3" FontSize="10" TextTrimming="CharacterEllipsis" Text="{Binding SamplingInterval}" />
 
-        <TextBlock Grid.Row="1" Grid.Column="0" Height="Auto" Margin="3" FontSize="10" FontWeight="Bold" Text="Iteration: " />
-        <TextBlock Grid.Row="1" Grid.Column="1" Height="Auto" Margin="3" FontSize="10" TextTrimming="CharacterEllipsis" />
+        <TextBlock Grid.Row="1" Grid.Column="0" Height="Auto" Margin="3" FontSize="10" FontWeight="Bold" Text="Number of Variables: " />
+        <TextBlock Grid.Row="1" Grid.Column="1" Height="Auto" Margin="3" FontSize="10" TextTrimming="CharacterEllipsis" Text="{Binding VariablesCount}" />
 
-        <TextBlock Grid.Row="1" Grid.Column="2" Height="Auto" Margin="6,3,3,3" FontSize="10" FontWeight="Bold" Text="Person: " />
-        <TextBlock Grid.Row="1" Grid.Column="3" Height="Auto" Margin="3" FontSize="10" TextTrimming="CharacterEllipsis" />
+        <TextBlock Grid.Row="1" Grid.Column="2" Height="Auto" Margin="6,3,3,3" FontSize="10" FontWeight="Bold" Text="Server Start Time: " />
+        <TextBlock Grid.Row="1" Grid.Column="3" Height="Auto" Margin="3" FontSize="10" TextTrimming="CharacterEllipsis" Text="{Binding ServerStartTime}" />
 
-        <TextBlock Grid.Row="2" Grid.Column="2" Height="Auto" Margin="6,3,3,3" FontSize="10" FontWeight="Bold" Text="Domain Of Expertise:" />
-        <TextBlock Grid.Row="2" Grid.Column="3" Height="Auto" Margin="3" FontSize="10" TextTrimming="CharacterEllipsis" />
+        <TextBlock Grid.Row="2" Grid.Column="2" Height="Auto" Margin="6,3,3,3" FontSize="10" FontWeight="Bold" Text="Current Server Time: " />
+        <TextBlock Grid.Row="2" Grid.Column="3" Height="Auto" Margin="3" FontSize="10" TextTrimming="CharacterEllipsis" Text="{Binding CurrentServerTime}"/>
     </Grid>
 </UserControl>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEHP-ECOSIMPRO/pulls) open
- [x] I have verified that I am following the DEHP-EcosimPro [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEHP-ECOSIMPRO/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
fixes #35 
- Added some server and connection status properties to the DstBrowserHeaderViewModel
- Added capability of calling the Run and Reset server methods from the DstBrowserHeaderViewModel
- Added two methods for retrieving the server start and current times in the DstController

<!-- Thanks for contributing to DEHP-EcosimPro! -->